### PR TITLE
feat: add config arg from Nixpack CLI as input in action

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It's very opinionated out the box (as software should be!) but allows you to cus
 ## Inputs
 
 - `context`: The build's context, specifying the set of files located at the provided PATH or URL. It is required to point to your application source code.
+- `config`: The path to the config file (e.g nixpacks.toml). This is useful when the config file is not at the root of the context, for example in a mono-repository.
 - `tags`: A comma-separated list of tags to apply to the built image. Defaults to unix timestamp, git SHA, and `latest`.
 - `labels`: An optional, comma-separated list of metadata labels to add to the image.
 - `platforms`: An optional, comma-separated list of target platforms for the build.
@@ -38,6 +39,16 @@ It's very opinionated out the box (as software should be!) but allows you to cus
     uses: iloveitaly/github-action-nixpacks@main
     with:
       push: true
+```
+
+Mono-repository example:
+```yaml
+  - name: Build and push Docker images
+    uses: iloveitaly/github-action-nixpacks@main
+    with:
+      push: true
+      context: .
+      config: apps/your-app/nixpacks.toml
 ```
 
 Multi-architecture builds are easy:

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: "Build's context is the set of files located in the specified PATH"
     required: true
     default: "."
+  config:
+    description: "Path to nixpacks config file passed to --config"
+    required: false
   pkgs:
     description: "Provide additional nix packages to install in the environment"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,7 @@ runs:
         INPUT_LABELS: ${{ inputs.labels }}
         INPUT_PLATFORMS: ${{ inputs.platforms }}
         INPUT_CONTEXT: ${{ inputs.context }}
+        INPUT_CONFIG: ${{ inputs.config }}
         INPUT_PKGS: ${{ inputs.pkgs }}
         INPUT_APT: ${{ inputs.apt }}
         INPUT_PUSH: ${{ inputs.push }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,11 @@ for var in $(env | grep ^NIXPACKS_); do
   BUILD_CMD="$BUILD_CMD --env $var"
 done
 
+# add the config file path to the build command
+if [ -n "${INPUT_CONFIG}" ]; then
+  BUILD_CMD="$BUILD_CMD --config ${INPUT_CONFIG}"
+fi
+
 # Incorporate provided input parameters from actions.yml into the Nixpacks build command
 if [ -n "${INPUT_TAGS}" ]; then
   read -ra TAGS <<<"$(echo "$INPUT_TAGS" | tr ',\n' ' ')"


### PR DESCRIPTION
### Description 

Added the possibility to pass a new input called config that will be passed to the config argument to the nixpack build command. This is useful for custom nixpack config paths for example in a mono-repository.